### PR TITLE
feat(wordpress): add self-hosted WordPress CMS module

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Get-ChildItem -Path \"c:\\\\Users\\\\AndreasJensen\\\\Desktop\\\\TAPPaaS Git\\\\TAPPaaS Community - conrib\\\\Community\\\\src\\\\AndreasJe\\\\nextcloud-hub\\\\\" -Recurse -ErrorAction SilentlyContinue | Select-Object FullName)",
+      "Bash(dir \"c:\\\\Users\\\\AndreasJensen\\\\Desktop\\\\TAPPaaS Git\\\\TAPPaaS Community - conrib\\\\Community\\\\src\\\\AndreasJe\\\\nextcloud-hub\" /s /b)"
+    ]
+  }
+}

--- a/src/AndreasJe/wordpress/ADMIN.md
+++ b/src/AndreasJe/wordpress/ADMIN.md
@@ -1,0 +1,323 @@
+# WordPress — Admin Reference
+
+Commands run on the VM unless noted otherwise.
+
+## DNS & Domain Access
+
+OPNsense Dnsmasq is the DNS server for all LAN clients. It works in two layers:
+
+```
+LAN client asks: "what is wordpress.tappaas.qualiware.com?"
+        │
+        ▼
+  Dnsmasq (OPNsense)
+        │
+        ├── Local host entry exists? → answer immediately (no internet needed)
+        │
+        └── No entry? → forward to upstream public DNS → return result
+```
+
+| Layer | Where | Visible to | Use for |
+|-------|-------|------------|---------|
+| **Dnsmasq host entry** | OPNsense → Services → Dnsmasq DNS & DHCP → Hosts | LAN only | Internal testing, overrides |
+| **Public DNS record** | Your registrar (e.g. Cloudflare, namecheap) | Everyone | Production / internet access |
+
+### Internal access (LAN only)
+
+`wordpress.srv.internal` already resolves and works. The friendly URL
+(`wordpress.tappaas.qualiware.com`) is just an alias — it needs to resolve to OPNsense
+so Caddy can forward the request to `wordpress.srv.internal` exactly as it does today.
+
+Add one Dnsmasq host entry in OPNsense:
+
+| Field | Value |
+|-------|-------|
+| Host | `wordpress` |
+| Domain | `tappaas.qualiware.com` |
+| IP | `10.50.0.1` (OPNsense / firewall) |
+| Description | `TAPPaaS: wordpress` |
+
+Save → Apply. The flow becomes:
+
+```
+Client → wordpress.tappaas.qualiware.com
+       → 10.50.0.1 (Caddy on OPNsense)
+       → wordpress.srv.internal:80
+```
+
+### Going live (public access)
+
+Add an A record at your DNS registrar pointing to the OPNsense **WAN IP**:
+
+```
+wordpress.tappaas.qualiware.com  A  <OPNsense WAN IP>
+```
+
+Then remove the Dnsmasq host entry — LAN clients will resolve via public DNS.
+
+### Wildcard shortcut
+
+A wildcard covers all future TAPPaaS modules automatically:
+
+```
+*.tappaas.qualiware.com  A  <OPNsense WAN IP>
+```
+
+### Verify resolution
+
+```bash
+# From tappaas-cicd — confirms DNS resolves correctly
+dig wordpress.tappaas.qualiware.com
+
+# Should return 87.54.122.90 (OPNsense WAN IP)
+# Caddy on OPNsense then routes the request to wordpress.srv.internal:80
+```
+
+---
+
+## Troubleshooting
+
+### Site shows "Briefly unavailable for scheduled maintenance" / 503 on all pages
+
+WordPress creates a `.maintenance` file at the start of any update (plugin, theme, core) and removes it when done. If the browser tab is closed mid-update, or the request times out, the file is left behind and WordPress serves 503 to every visitor indefinitely.
+
+**Fix:**
+```bash
+sudo rm /var/lib/wordpress/.maintenance
+```
+
+The site comes back immediately — no restart needed.
+
+---
+
+## Services
+
+```bash
+systemctl status wordpress-container nginx mysql redis-wordpress
+
+systemctl restart wordpress-container
+systemctl restart mysql
+systemctl restart redis-wordpress
+```
+
+Unit names are derived from `vmName` in `wordpress.nix`. With the default `vmName = "wordpress"`:
+
+| Service         | Unit                        |
+|-----------------|-----------------------------|
+| WordPress       | `wordpress-container`       |
+| Redis           | `redis-wordpress`           |
+| MariaDB         | `mysql`                     |
+| Secrets init    | `generate-wordpress-secrets`|
+
+## Logs
+
+```bash
+journalctl -u wordpress-container -f
+journalctl -u mysql -f
+journalctl -u redis-wordpress -f
+journalctl -u generate-wordpress-secrets
+```
+
+## Database
+
+All commands run on the VM. MariaDB listens on `127.0.0.1:3306` only — not reachable from outside.
+
+### Connect
+
+```bash
+# Interactive shell (DB name = vmName)
+mysql -u root wordpress
+
+# One-liner
+mysql -u root -e "SHOW PROCESSLIST;"
+mysql -u root -e "SELECT table_schema, ROUND(SUM(data_length+index_length)/1024/1024,1) AS MB FROM information_schema.tables GROUP BY table_schema;"
+```
+
+### From tappaas-cicd over SSH
+
+```bash
+# Run a query on the VM without opening an interactive session
+ssh tappaas@wordpress.srv.internal \
+  "sudo mysql -u root -e 'SELECT ID, user_login, user_email FROM wordpress.wp_users;'"
+
+# Dump the database
+ssh tappaas@wordpress.srv.internal \
+  "sudo mysqldump --single-transaction wordpress" > wordpress-$(date +%Y%m%d).sql
+```
+
+### Common queries
+
+```bash
+# List all users
+mysql -u root -e "SELECT ID, user_login, user_email, user_registered FROM wordpress.wp_users;"
+
+# Check table sizes
+mysql -u root -e "
+  SELECT table_name, ROUND((data_length+index_length)/1024/1024,2) AS MB
+  FROM information_schema.tables
+  WHERE table_schema='wordpress'
+  ORDER BY MB DESC;"
+
+# Count posts by status
+mysql -u root -e "SELECT post_status, COUNT(*) FROM wordpress.wp_posts GROUP BY post_status;"
+
+# Check active options (site URL, admin email)
+mysql -u root -e "SELECT option_name, option_value FROM wordpress.wp_options WHERE option_name IN ('siteurl','blogname','admin_email');"
+```
+
+### Change a user's email
+
+```bash
+# Via WP-CLI (if installed)
+podman exec wordpress wp --allow-root --path=/var/www/html \
+  user update username --user_email='new@example.com'
+
+# Via SQL (always available)
+mysql -u root -e "UPDATE wordpress.wp_users SET user_email='new@example.com' WHERE user_login='username';"
+
+# Verify
+mysql -u root -e "SELECT user_login, user_email FROM wordpress.wp_users WHERE user_login='username';"
+```
+
+### Reset a user password
+
+```bash
+# 1. Find the username
+mysql -u root -e "SELECT ID, user_login, user_email FROM wordpress.wp_users;"
+
+# 2. Generate a proper WordPress password hash using PHP inside the container
+HASH=$(podman exec wordpress php -r "
+require '/var/www/html/wp-load.php';
+echo wp_hash_password('your-new-password');
+")
+
+# 3. Write it (replace 'username' with the actual login from step 1)
+mysql -u root -e "UPDATE wordpress.wp_users SET user_pass='${HASH}' WHERE user_login='username';"
+```
+
+> Using `wp_hash_password()` inside the container ensures WordPress's own hashing
+> (phpass/bcrypt) is used. Plain `MD5()` in SQL works as a fallback but is insecure.
+
+## WP-CLI
+
+The standard `wordpress:6.7-fpm` image does **not** include WP-CLI. Use `podman exec` with PHP or install WP-CLI into the container.
+
+### Install WP-CLI (one-time, survives restarts via the bind-mount)
+
+```bash
+podman exec -u root wordpress bash -c "
+  curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+  chmod +x wp-cli.phar
+  mv wp-cli.phar /usr/local/bin/wp
+"
+```
+
+### WP-CLI examples
+
+```bash
+# All WP-CLI commands need --allow-root (container runs PHP-FPM as www-data
+# but exec defaults to root) and --path to point at the webroot.
+
+# Check WordPress version and status
+podman exec wordpress wp --allow-root --path=/var/www/html core version
+podman exec wordpress wp --allow-root --path=/var/www/html core check-update
+
+# List users
+podman exec wordpress wp --allow-root --path=/var/www/html user list
+
+# Reset a user password
+podman exec wordpress wp --allow-root --path=/var/www/html \
+  user update username --user_pass='new-password'
+
+# List installed plugins and their status
+podman exec wordpress wp --allow-root --path=/var/www/html plugin list
+
+# Update all plugins
+podman exec wordpress wp --allow-root --path=/var/www/html plugin update --all
+
+# Activate / deactivate a plugin
+podman exec wordpress wp --allow-root --path=/var/www/html plugin activate redis-cache
+podman exec wordpress wp --allow-root --path=/var/www/html plugin deactivate redis-cache
+
+# Flush the Redis object cache
+podman exec wordpress wp --allow-root --path=/var/www/html cache flush
+
+# Export the database (alternative to mysqldump)
+podman exec wordpress wp --allow-root --path=/var/www/html db export - > wordpress-$(date +%Y%m%d).sql
+
+# Search-replace URL (useful after moving domains)
+podman exec wordpress wp --allow-root --path=/var/www/html \
+  search-replace 'http://old-domain.com' 'https://new-domain.com' --all-tables
+```
+
+### PHP one-liners (no WP-CLI needed)
+
+```bash
+# Run arbitrary WordPress PHP — loads the full WP environment
+podman exec wordpress php -r "
+require '/var/www/html/wp-load.php';
+echo get_bloginfo('url') . PHP_EOL;
+"
+
+# Get site URL and admin email
+podman exec wordpress php -r "
+require '/var/www/html/wp-load.php';
+echo 'URL:   ' . get_option('siteurl') . PHP_EOL;
+echo 'Email: ' . get_option('admin_email') . PHP_EOL;
+"
+```
+
+## Redis
+
+```bash
+redis-cli -p 6380 PING
+redis-cli -p 6380 INFO stats
+redis-cli -p 6380 DBSIZE
+redis-cli -p 6380 FLUSHALL    # safe — cache rebuilds automatically
+```
+
+## Secrets
+
+```bash
+sudo cat /etc/secrets/wordpress.env    # path uses vmName: /etc/secrets/<vmname>.env
+```
+
+## Backups
+
+```bash
+systemctl start backup-wordpress-db       # manual DB backup
+systemctl start backup-wordpress-data     # manual file backup
+
+ls -lh /var/backup/wordpress-db/
+ls -lh /var/backup/wordpress-data/
+
+systemctl list-timers | grep wordpress
+```
+
+Backup paths use `vmName`: `/var/backup/<vmname>-db/` and `/var/backup/<vmname>-data/`.
+
+## Disk
+
+```bash
+df -h /var/lib/wordpress                          # data volume (path = /var/lib/<vmname>)
+du -sh /var/lib/wordpress/wp-content/uploads
+du -sh /var/backup/wordpress-*
+```
+
+## NixOS
+
+```bash
+nixos-rebuild switch                  # apply config changes
+nixos-rebuild switch --rollback       # roll back last change
+nixos-rebuild list-generations
+```
+
+## Renaming the VM
+
+1. Edit `wordpress.nix`: `vmName = "newname";`
+2. Edit `wordpress.json`: `"vmname": "newname"`
+3. Run `update-module.sh newname` from tappaas-cicd
+
+All unit names, socket paths, data dirs (`/var/lib/<vmname>`), backup dirs, DB name, and secrets path update automatically on the next `nixos-rebuild switch`.
+
+> **Note:** Renaming after data exists requires migrating `/var/lib/wordpress` → `/var/lib/newname` and the MariaDB database manually before rebuilding.

--- a/src/AndreasJe/wordpress/BACKLOG.md
+++ b/src/AndreasJe/wordpress/BACKLOG.md
@@ -1,0 +1,15 @@
+# WordPress — Backlog
+
+## Known limitations
+
+- **Single disk** — OS and data share one volume on tanka1. When the TAPPaaS schema supports multi-disk VMs, split into OS disk (tanka1, 16G) and data disk (50G+) mounting `/var/lib/<vmname>` and `/var/lib/mysql` separately.
+
+- **Application backups are on-VM only** — DB dumps and file archives write to `/var/backup/` on the same disk. Proxmox VM snapshots cover full restore, but granular recovery depends on these dumps surviving a disk failure. Backups should be shipped off-VM to the TAPPaaS backup target.
+
+- **`identity:identity` not wired** — dependency declared but Authentik OIDC is not connected by default. See INSTALL.md — Authentik SSO.
+
+## Future work
+
+- Multi-disk schema support
+- Off-VM backup shipping for DB dumps and file archives
+- WP-CLI integration for plugin/theme management without wp-admin

--- a/src/AndreasJe/wordpress/INSTALL.md
+++ b/src/AndreasJe/wordpress/INSTALL.md
@@ -1,0 +1,149 @@
+# WordPress — Installation
+
+## Prerequisites
+
+- `firewall:proxy` and `backup:vm` operational
+- VMID 620 free in Proxmox
+- DNS record pointing `wordpress.<yourdomain>` to Caddy
+
+## Install
+
+```bash
+cd /home/tappaas/TAPPaaS/src/apps/wordpress
+install-module.sh wordpress
+```
+
+`install-module.sh` provisions the VM via `cluster:vm`, wires all `dependsOn` services, then calls `install.sh`. `install.sh` prompts for the public domain and writes it to `/etc/secrets/wordpress.env` on the VM.
+
+Override node or VMID:
+
+```bash
+install-module.sh wordpress --node tappaas2
+install-module.sh wordpress --vmid 621
+```
+
+### Renaming before install
+
+Edit two lines before running `install-module.sh`:
+
+- `wordpress.nix`: `vmName = "myblog";`
+- `wordpress.json`: `"vmname": "myblog"`
+
+## Post-install
+
+1. Open `https://wordpress.<yourdomain>` and complete the WordPress setup wizard.
+2. Caddy is already wired — no manual proxy steps needed.
+
+## Verify
+
+```bash
+./test.sh wordpress
+```
+
+## Update
+
+```bash
+update-module.sh wordpress                   # deploy NixOS config changes
+./update.sh wordpress --container            # also pull new WordPress image
+```
+
+## Delete
+
+```bash
+delete-module.sh wordpress
+delete-module.sh wordpress --force           # bypass reverse-dependency checks
+```
+
+---
+
+## Authentik SSO (optional)
+
+Admins and editors only. Public/commenter accounts use native WordPress login.
+
+**1. Create OIDC provider in Authentik**
+
+- Name: `wordpress`
+- Redirect URI: `https://wordpress.<yourdomain>/wp-admin/admin-ajax.php?action=openid-connect-authorize`
+
+**2. Group mappings**
+
+| Authentik group   | WordPress role |
+|-------------------|----------------|
+| wordpress-admins  | Administrator  |
+| wordpress-editors | Editor         |
+
+**3. Install plugin**
+
+In wp-admin: **OpenID Connect Generic Client** by daggerhart.
+
+**4. Fill OIDC secrets**
+
+```bash
+sudo vim /etc/secrets/wordpress.env
+```
+
+Add:
+
+```
+OIDC_CLIENT_ID=wordpress
+OIDC_CLIENT_SECRET=<from Authentik>
+OIDC_ENDPOINT_LOGIN_URL=https://authentik.<domain>/application/o/wordpress/authorize
+OIDC_ENDPOINT_TOKEN_URL=https://authentik.<domain>/application/o/wordpress/token
+OIDC_ENDPOINT_USERINFO_URL=https://authentik.<domain>/application/o/wordpress/userinfo
+OIDC_ENDPOINT_LOGOUT_URL=https://authentik.<domain>/application/o/wordpress/end-session
+```
+
+**5. Enable in `wordpress.nix`**
+
+Uncomment the `OIDC_*` env var block in the container service, then:
+
+```bash
+update-module.sh wordpress
+```
+
+**6. Disable native login for admin accounts** in the plugin settings once SSO is confirmed.
+
+---
+
+## Upgrading WordPress
+
+Edit the version in `wordpress.nix`:
+
+```nix
+wordpress = "6.8-fpm";
+```
+
+```bash
+./update.sh wordpress --container
+```
+
+## Backup & restore
+
+Backups at `/var/backup/<vmname>-db/` and `/var/backup/<vmname>-data/`, retained 30 days.
+
+Restore:
+
+```bash
+systemctl stop wordpress-container
+gunzip -c /var/backup/wordpress-db/wordpress-YYYYMMDD.sql.gz | mysql wordpress
+tar xzf /var/backup/wordpress-data/wordpress-YYYYMMDD.tar.gz -C /
+systemctl start wordpress-container
+```
+
+## Performance tuning
+
+Enabled by default — no config needed:
+
+- PHP-FPM dynamic pool, max 8 workers
+- OPcache 128MB
+- Nginx static asset cache (1-year headers)
+- Redis 256MB object cache on port 6380
+- MariaDB query cache 64MB
+
+For full-page caching, install **W3 Total Cache** or **WP Super Cache** in wp-admin and point Redis at `127.0.0.1:6380`.
+
+Disable slow query log once tuned:
+
+```nix
+slow_query_log = 0;
+```

--- a/src/AndreasJe/wordpress/LICENSE
+++ b/src/AndreasJe/wordpress/LICENSE
@@ -1,0 +1,8 @@
+Mozilla Public License Version 2.0
+==================================
+
+Copyright (c) 2026 TAPPaaS Contributors
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/AndreasJe/wordpress/README.md
+++ b/src/AndreasJe/wordpress/README.md
@@ -1,0 +1,104 @@
+# WordPress on TAPPaaS
+
+**Version:** 0.4.0 | **Status:** Development | **VMID:** 620 | **Zone:** dmz
+
+Self-hosted WordPress CMS on NixOS — MariaDB, Redis, PHP-FPM, Nginx, Podman.
+
+## Architecture
+
+```
+Internet → OPNsense/Caddy (dmz) → wordpress.srv.internal:8080
+                                        │
+                                   Nginx :8080
+                                   ├── PHP-FPM (OPcache, 8 workers)
+                                   ├── WordPress container (Podman)
+                                   ├── MariaDB :3306 (localhost)
+                                   └── Redis :6380 (localhost)
+```
+
+Caddy reverse proxy wired automatically via `firewall:proxy`.
+
+## VM specs
+
+| Resource | Value |
+|----------|-------|
+| vCPU     | 2 |
+| Memory   | 2 GB |
+| Disk     | 20G on tanka1 |
+| Network  | dmz zone (`wordpress.dmz.internal`) |
+
+## Renaming
+
+Change `vmName` in `wordpress.nix` and `vmname` in `wordpress.json` — hostname, unit names, socket paths, data dirs, and DB all derive from it.
+
+## Lifecycle
+
+```bash
+install-module.sh wordpress
+update-module.sh wordpress
+delete-module.sh wordpress
+```
+
+## Secrets
+
+Auto-generated on first boot at `/etc/secrets/<vmname>.env` (mode 600).
+
+## Debugging
+
+**503 / blank page**
+```bash
+ssh tappaas@wordpress.dmz.internal
+podman ps                                          # container must be listed
+ss -tlnp | grep :9000                             # PHP-FPM must be listening
+podman logs wordpress                              # startup errors
+systemctl status wordpress-container.service
+```
+
+**403 on `/wp-admin/` or PHP pages**
+Nginx must have `index index.php` in its config — without it, directory requests return 403 instead of falling through to `index.php`. Already set in `wordpress.nix`; if you see this after a rebuild, verify the config applied:
+```bash
+nginx -T | grep "index index.php"
+```
+
+**403 on CSS / JS after first boot**
+PHP-FPM (uid 33, www-data inside container) creates files as 0640. The host Nginx reads them as "other" and gets denied. The `ExecStartPost` fix-perms script handles this automatically, but it only fires once at container start. If you deploy files manually or install a plugin via CLI, re-run it:
+```bash
+find /var/lib/wordpress -type f ! -perm -a+r -exec chmod a+r {} \;
+find /var/lib/wordpress -type d ! -perm -a+rx -exec chmod a+rx {} \;
+```
+Do **not** chown to `nginx` — PHP-FPM runs as uid 33, not the host nginx uid, and will get permission denied on writes.
+
+**DB authentication failure on fresh install**
+MariaDB is initialised with a `PLACEHOLDER` password; the `wordpress-db-password-sync` service updates it from the generated secrets file. If the container starts before the sync completes, WordPress logs `Access denied for user 'wordpress'@'127.0.0.1'`. Check:
+```bash
+systemctl status wordpress-db-password-sync.service
+journalctl -u wordpress-db-password-sync.service
+```
+If it failed, restart it, then restart the container.
+
+**Redirect loop or mixed-content errors behind Caddy**
+WordPress must know it is behind HTTPS. `WORDPRESS_CONFIG_EXTRA` sets `$_SERVER['HTTPS']='on'` and hard-codes `WP_HOME`/`WP_SITEURL` to the proxy domain. If you change `proxyDomain` in `wordpress.json`, rebuild and also update the `siteurl`/`home` rows in `wp_options` (or the site will redirect to the old domain):
+```bash
+mysql -u root wordpress -e "SELECT option_name, option_value FROM wp_options WHERE option_name IN ('siteurl','home');"
+```
+
+**Redis not caching**
+Redis runs on port **6380** (not 6379) to avoid conflicts with other Redis instances on the same host. The WordPress Redis Object Cache plugin must point to port 6380. Verify it is up:
+```bash
+redis-cli -h 127.0.0.1 -p 6380 ping    # expect: PONG
+```
+
+**Slow queries**
+MariaDB slow query logging is enabled (`long_query_time = 1 s`). Queries exceeding 1 second are written to `/var/log/mysql/slow.log`.
+
+## Documentation
+
+| File | Contents |
+|------|----------|
+| [INSTALL.md](INSTALL.md) | Step-by-step install, post-install wizard, rename before install, Authentik SSO setup, WordPress version upgrades, backup & restore, and performance tuning reference |
+| [ADMIN.md](ADMIN.md) | Day-to-day operations: DNS setup (internal override + public record), service and log commands, database queries and password reset, WP-CLI usage, Redis, secrets, backups, and disk usage |
+| [BACKLOG.md](BACKLOG.md) | Known limitations and planned improvements (single-disk layout, off-VM backup shipping, WP-CLI integration) |
+
+## License
+
+Mozilla Public License 2.0

--- a/src/AndreasJe/wordpress/delete.sh
+++ b/src/AndreasJe/wordpress/delete.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Called by delete-module.sh before VM teardown and reverse dependency unwiring.
+set -euo pipefail
+
+. /home/tappaas/bin/common-install-routines.sh wordpress
+
+VMNAME="$(get_config_value 'vmname')"
+
+info "Stopping WordPress services on ${VMNAME}"
+ssh "root@${VMNAME}" bash << 'REMOTE'
+  systemctl stop wordpress-container                     || true
+  systemctl stop nginx                                   || true
+  systemctl stop redis-wordpress                         || true
+  systemctl stop mysql                                   || true
+  systemctl disable --now backup-wordpress-db.timer      || true
+  systemctl disable --now backup-wordpress-data.timer    || true
+  systemctl disable --now backup-wordpress-cleanup.timer || true
+  rm -f /etc/nixos/wordpress.nix
+  sed -i "/wordpress.nix/d" /etc/nixos/configuration.nix
+REMOTE
+
+info "Done — VM teardown continues via delete-module.sh"

--- a/src/AndreasJe/wordpress/install.sh
+++ b/src/AndreasJe/wordpress/install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# TAPPaaS WordPress Module Installation
+#
+# Copies the NixOS configuration and JSON to the VM and runs nixos-rebuild.
+# Domain is read from wordpress.json (proxyDomain). No domain prompt needed.
+# The VM is already provisioned by cluster:vm / templates:nixos before this
+# script is called.
+#
+# Usage: install.sh <vmname>
+# Example: install.sh wordpress
+#
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+readonly SCRIPT_NAME
+
+# shellcheck source=../../foundation/tappaas-cicd/scripts/common-install-routines.sh
+. /home/tappaas/bin/common-install-routines.sh
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+VMNAME="$(get_config_value 'vmname' "${1:-}")"
+ZONE0NAME="$(get_config_value 'zone0' 'mgmt')"
+readonly VMNAME ZONE0NAME
+
+VM_HOST="${VMNAME}.${ZONE0NAME}.internal"
+readonly VM_HOST
+
+readonly SSH_OPTS="-o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o BatchMode=yes"
+
+# ── Usage ──────────────────────────────────────────────────────────────
+
+usage() {
+    cat << EOF
+Usage: ${SCRIPT_NAME} <vmname>
+
+Install the WordPress module. Prompts for the public domain then writes
+it to the VM and starts the container.
+
+Arguments:
+    vmname    Name of the VM (must have config in /home/tappaas/config/)
+
+Examples:
+    ${SCRIPT_NAME} wordpress
+EOF
+}
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+
+    if [[ -z "${1:-}" ]]; then
+        error "Module name is required"
+        usage
+        exit 1
+    fi
+
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    local site_domain
+    site_domain="$(jq -r '.proxyDomain' "${script_dir}/wordpress.json")"
+
+    info "Deploying WordPress to ${VM_HOST} (${site_domain})..."
+
+    # ── Step 1: Copy NixOS config and JSON to VM ───────────────────────
+    # shellcheck disable=SC2086
+    scp ${SSH_OPTS} \
+        "${script_dir}/wordpress.nix" \
+        "${script_dir}/wordpress.json" \
+        "tappaas@${VM_HOST}:/tmp/"
+
+    # ── Step 2: Apply NixOS configuration ─────────────────────────────
+    # shellcheck disable=SC2086
+    ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "sudo cp /tmp/wordpress.nix /etc/nixos/configuration.nix && \
+         sudo cp /tmp/wordpress.json /etc/nixos/wordpress.json && \
+         sudo nixos-rebuild switch"
+
+    echo ""
+    info "${GN}✓${CL} WordPress deployed at https://${site_domain}"
+}
+
+main "$@"

--- a/src/AndreasJe/wordpress/test.sh
+++ b/src/AndreasJe/wordpress/test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# TAPPaaS WordPress Health & Regression Test
+#
+# Validates that the WordPress module is running correctly by checking
+# SSH connectivity, service status, HTTP endpoint, MariaDB, and Redis.
+#
+# Usage: ./test.sh <vmname>
+# Example: ./test.sh wordpress
+#
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+readonly SCRIPT_NAME
+
+# shellcheck source=../../foundation/tappaas-cicd/scripts/common-install-routines.sh
+. /home/tappaas/bin/common-install-routines.sh
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+VMNAME="$(get_config_value 'vmname' "${1:-}")"
+VMID="$(get_config_value 'vmid')"
+ZONE0NAME="$(get_config_value 'zone0' 'mgmt')"
+readonly VMNAME VMID ZONE0NAME
+
+VM_HOST="${VMNAME}.${ZONE0NAME}.internal"
+readonly VM_HOST
+
+readonly SSH_OPTS="-o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o BatchMode=yes"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ── Helper functions ───────────────────────────────────────────────────
+
+usage() {
+    cat << EOF
+Usage: ${SCRIPT_NAME} <vmname>
+
+Run health and regression checks for the WordPress module.
+
+Arguments:
+    vmname    Name of the VM (must have config in /home/tappaas/config/)
+
+Examples:
+    ${SCRIPT_NAME} wordpress
+EOF
+}
+
+check_pass() {
+    info "  ${GN}✓${CL} $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+check_fail() {
+    error "  ✗ $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# ── Test functions ─────────────────────────────────────────────────────
+
+check_ssh() {
+    info "Check 1: SSH connectivity to ${VM_HOST}"
+    # shellcheck disable=SC2086
+    if ssh ${SSH_OPTS} "tappaas@${VM_HOST}" "exit 0" &>/dev/null; then
+        check_pass "SSH connection successful"
+    else
+        check_fail "SSH connection failed to tappaas@${VM_HOST}"
+    fi
+}
+
+check_mariadb() {
+    info "Check 2: MariaDB running"
+    # shellcheck disable=SC2086
+    if ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "systemctl is-active mysql" &>/dev/null; then
+        check_pass "MariaDB is running"
+    else
+        check_fail "MariaDB is not running"
+    fi
+}
+
+check_redis() {
+    info "Check 3: Redis responding"
+    local pong
+    # shellcheck disable=SC2086
+    pong=$(ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "redis-cli -h 127.0.0.1 -p 6380 ping" 2>/dev/null) || true
+    if [[ "${pong}" == "PONG" ]]; then
+        check_pass "Redis is responding"
+    else
+        check_fail "Redis is not responding (got: ${pong:-no response})"
+    fi
+}
+
+check_php_fpm() {
+    info "Check 4: WordPress container PHP-FPM responding on port 9000"
+    # shellcheck disable=SC2086
+    if ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "ss -tlnp | grep -q ':9000'" &>/dev/null; then
+        check_pass "PHP-FPM is listening on port 9000"
+    else
+        check_fail "PHP-FPM is not listening on port 9000 (container may not be running)"
+    fi
+}
+
+check_http() {
+    info "Check 5: HTTP health check on port 8080"
+    local http_code
+    # shellcheck disable=SC2086
+    http_code=$(ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost:8080/" 2>/dev/null) || true
+    if [[ "${http_code}" =~ ^(200|301|302)$ ]]; then
+        check_pass "HTTP responding (status ${http_code})"
+    else
+        check_fail "HTTP not responding (status: ${http_code:-timeout})"
+    fi
+}
+
+check_secrets() {
+    info "Check 6: Secrets file present"
+    # shellcheck disable=SC2086
+    if ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "test -f /etc/secrets/${VMNAME}.env" &>/dev/null; then
+        check_pass "Secrets file present"
+    else
+        check_fail "Secrets file missing at /etc/secrets/${VMNAME}.env"
+    fi
+}
+
+check_backup_timers() {
+    info "Check 7: Backup timers active"
+    local db_active data_active
+    # shellcheck disable=SC2086
+    db_active=$(ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "systemctl is-active backup-${VMNAME}-db.timer" 2>/dev/null) || true
+    # shellcheck disable=SC2086
+    data_active=$(ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "systemctl is-active backup-${VMNAME}-data.timer" 2>/dev/null) || true
+    if [[ "${db_active}" == "active" && "${data_active}" == "active" ]]; then
+        check_pass "Both backup timers are active"
+    else
+        check_fail "Backup timers not active (db: ${db_active:-unknown}, data: ${data_active:-unknown})"
+    fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+
+    if [[ -z "${1:-}" ]]; then
+        error "Module name is required"
+        usage
+        exit 1
+    fi
+
+    info "=== WordPress Health Check ==="
+    info "VM: ${VMNAME} (VMID: ${VMID}) at ${VM_HOST}"
+    echo ""
+
+    check_ssh
+    check_mariadb
+    check_redis
+    check_php_fpm
+    check_http
+    check_secrets
+    check_backup_timers
+
+    echo ""
+    info "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+
+    if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+        error "Health check FAILED — ${FAIL_COUNT} check(s) did not pass"
+        exit 1
+    fi
+
+    info "${GN}All health checks passed${CL}"
+    exit 0
+}
+
+main "$@"

--- a/src/AndreasJe/wordpress/update.sh
+++ b/src/AndreasJe/wordpress/update.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# TAPPaaS WordPress Module Update
+#
+# Deploys an updated wordpress.nix to the VM and runs nixos-rebuild switch.
+# Optionally pulls a new WordPress container image and restarts it.
+#
+# Usage: update.sh <vmname> [--container]
+# Example: update.sh wordpress
+#          update.sh wordpress --container
+#
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+readonly SCRIPT_NAME
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+# shellcheck source=../../foundation/tappaas-cicd/scripts/common-install-routines.sh
+. /home/tappaas/bin/common-install-routines.sh
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+VMNAME="$(get_config_value 'vmname' "${1:-}")"
+VMID="$(get_config_value 'vmid')"
+NODE="$(get_config_value 'node' "$(get_node_hostname 0)")"
+ZONE0NAME="$(get_config_value 'zone0' 'mgmt')"
+HANODE="$(get_config_value 'HANode' "$(get_default_ha_node "$NODE")")"
+readonly VMNAME VMID NODE ZONE0NAME HANODE
+
+VM_HOST="${VMNAME}.${ZONE0NAME}.internal"
+readonly VM_HOST
+
+readonly SSH_OPTS="-o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o BatchMode=yes"
+
+# ── Usage ──────────────────────────────────────────────────────────────
+
+usage() {
+    cat << EOF
+Usage: ${SCRIPT_NAME} <vmname> [--container]
+
+Deploy updated NixOS configuration to the WordPress VM.
+
+Arguments:
+    vmname        Name of the VM (must have config in /home/tappaas/config/)
+
+Options:
+    --container   Also pull a new WordPress image and restart the container
+    -h, --help    Show this help message
+
+Examples:
+    ${SCRIPT_NAME} wordpress
+    ${SCRIPT_NAME} wordpress --container
+EOF
+}
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+main() {
+    local update_container=false
+
+    for arg in "$@"; do
+        case "${arg}" in
+            --container) update_container=true ;;
+            -h|--help)   usage; exit 0 ;;
+        esac
+    done
+
+    if [[ -z "${1:-}" ]]; then
+        error "Module name is required"
+        usage
+        exit 1
+    fi
+
+    info "=== WordPress Update ==="
+    info "VM: ${VMNAME} (VMID: ${VMID}) at ${VM_HOST}"
+    echo ""
+
+    # ── Step 1: Deploy NixOS configuration ────────────────────────────
+    info "Step 1: Deploy wordpress.nix"
+    # shellcheck disable=SC2086
+    scp ${SSH_OPTS} "${SCRIPT_DIR}/wordpress.nix" "${SCRIPT_DIR}/wordpress.json" "tappaas@${VM_HOST}:/tmp/"
+    # shellcheck disable=SC2086
+    ssh ${SSH_OPTS} "tappaas@${VM_HOST}" \
+        "sudo cp /tmp/wordpress.nix /etc/nixos/configuration.nix && \
+         sudo cp /tmp/wordpress.json /etc/nixos/wordpress.json && \
+         sudo nixos-rebuild switch"
+    info "${GN}✓${CL} NixOS configuration applied"
+
+    # ── Step 2: Optional container image update ────────────────────────
+    if [[ "${update_container}" == "true" ]]; then
+        info ""
+        info "Step 2: Pull new WordPress image and restart container"
+        # shellcheck disable=SC2086
+        ssh ${SSH_OPTS} "tappaas@${VM_HOST}" bash << 'REMOTE'
+            sudo podman pull docker.io/wordpress:latest
+            sudo systemctl restart wordpress-container
+REMOTE
+        info "${GN}✓${CL} Container updated and restarted"
+    fi
+
+    echo ""
+    info "=== Update Complete ==="
+    info "VM: ${VMNAME} (VMID: ${VMID})"
+    info "Node: ${NODE}"
+    info "Zone: ${ZONE0NAME}"
+    if [[ -n "${HANODE:-}" ]]; then
+        info "HA Node: ${HANODE}"
+    fi
+}
+
+main "$@"

--- a/src/AndreasJe/wordpress/wordpress.json
+++ b/src/AndreasJe/wordpress/wordpress.json
@@ -1,0 +1,30 @@
+{
+  "description": "WordPress CMS - self-hosted content platform",
+  "version": "0.4.0",
+  "releaseDate": "2026-03-08",
+  "maintainer": "@AndreasJe",
+  "status": "Development",
+  "vmname": "wordpress",
+  "os": "nixos",
+  "vmid": 620,
+  "vmtag": "TAPPaaS,App",
+  "cores": 2,
+  "memory": "4048",
+  "diskSize": "20G",
+  "storage": "tanka1",
+  "imageType": "clone",
+  "image": "8080",
+  "bridge0": "lan",
+  "zone0": "dmz",
+  "proxyDomain": "wordpress.example.com",
+  "proxyPort": 80,
+  "dependsOn": [
+    "cluster:vm",
+    "cluster:ha",
+    "templates:nixos",
+    "backup:vm",
+    "identity:identity",
+    "firewall:proxy"
+  ],
+  "provides": []
+}

--- a/src/AndreasJe/wordpress/wordpress.nix
+++ b/src/AndreasJe/wordpress/wordpress.nix
@@ -1,0 +1,446 @@
+# Copyright (c) 2025 TAPPaaS org
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# ============================================================================
+# TAPPaaS - WordPress CMS
+# ============================================================================
+# Version: 0.4.0
+# Date: 2026-04-29
+# Maintainer: @AndreasJe
+#
+# Architecture:
+# - WordPress (PHP-FPM) via Podman container
+# - Nginx reverse proxy (port 8080)
+# - MariaDB 11.x backend
+# - Redis object cache (named instance, port 6380)
+#
+# Network: DMZ zone (VLAN 610, 10.6.0.0/24)
+# Firewall: ports 22 (SSH) + 8080 (WordPress HTTP)
+# Secrets: Auto-generated on first boot at /etc/secrets/<vmName>.env
+# Backups: Daily DB dump + file archive, 30-day retention
+#
+# Rename: change vmName below — hostname, services, paths, and DB all follow.
+#
+# ============================================================================
+
+{ config, lib, pkgs, modulesPath, ... }:
+
+let
+  meta        = builtins.fromJSON (builtins.readFile ./wordpress.json);
+  vmName      = meta.vmname;
+  domain      = meta.proxyDomain;
+  versions    = {
+    wordpress = "6.7-fpm";
+  };
+  secretsFile = "/etc/secrets/${vmName}.env";
+in
+{
+
+  # ==========================================================================
+  # IMPORTS
+  # ==========================================================================
+
+  imports = [
+    /etc/nixos/hardware-configuration.nix
+  ];
+
+  # ==========================================================================
+  # BOOT
+  # ==========================================================================
+
+  boot.loader.systemd-boot.enable      = lib.mkDefault true;
+  boot.loader.efi.canTouchEfiVariables = lib.mkDefault true;
+  boot.growPartition                   = lib.mkDefault true;
+
+  # ==========================================================================
+  # CLOUD-INIT
+  # ==========================================================================
+
+  services.cloud-init = {
+    enable         = true;
+    network.enable = false;
+  };
+
+  # ==========================================================================
+  # NETWORKING
+  # ==========================================================================
+
+  networking.hostName = lib.mkDefault vmName;
+  networking.networkmanager.enable = true;
+  networking.networkmanager.ensureProfiles.profiles.tappaas-ethernet = {
+    connection = { id = "tappaas-ethernet"; type = "ethernet"; autoconnect = "true"; autoconnect-priority = "100"; };
+    ipv4       = { method = "auto"; };
+    ipv6       = { method = "auto"; addr-gen-mode = "default"; };
+  };
+
+  systemd.network.enable             = lib.mkForce false;
+  systemd.network.wait-online.enable = lib.mkForce false;
+
+  systemd.services."serial-getty@ttyS0" = {
+    enable            = true;
+    wantedBy          = [ "getty.target" ];
+    serviceConfig.Restart = "always";
+  };
+
+  networking.firewall = {
+    enable          = true;
+    allowedTCPPorts = [ 22 80 ];
+  };
+
+  # ==========================================================================
+  # TIME ZONE
+  # ==========================================================================
+
+  time.timeZone = lib.mkDefault "Europe/Amsterdam";
+
+  # ==========================================================================
+  # USERS & SECURITY
+  # ==========================================================================
+
+  users.users.tappaas = {
+    isNormalUser = true;
+    extraGroups  = [ "wheel" "networkmanager" ];
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  # ==========================================================================
+  # NIX SETTINGS
+  # ==========================================================================
+
+  nix.settings.trusted-users         = [ "root" "@wheel" ];
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  nixpkgs.config.allowUnfree          = true;
+
+  nix.gc = {
+    automatic = true;
+    dates     = "weekly";
+    options   = "--delete-older-than 30d";
+  };
+
+  nix.optimise = {
+    automatic = true;
+    dates     = [ "weekly" ];
+  };
+
+  # ==========================================================================
+  # ESSENTIAL SERVICES
+  # ==========================================================================
+
+  services.qemuGuest.enable = true;
+
+  services.openssh = {
+    enable   = true;
+    settings = {
+      PasswordAuthentication = false;
+      PermitRootLogin        = "no";
+    };
+  };
+
+  programs.ssh.startAgent = true;
+
+  # ==========================================================================
+  # NGINX
+  # ==========================================================================
+
+  services.nginx = {
+    enable = true;
+    virtualHosts."${vmName}" = {
+      listen = [{ addr = "0.0.0.0"; port = 80; }];
+      root   = "/var/lib/${vmName}";
+      # Fix: without this nginx returns 403 on directory requests (e.g. /wp-admin/)
+      # because it does not know to look for index.php inside subdirectories.
+      extraConfig = ''
+        index index.php index.html index.htm;
+        client_max_body_size 128M;
+      '';
+      locations."/" = {
+        tryFiles = "$uri $uri/ /index.php?$args";
+      };
+      locations."~ \\.php$" = {
+        extraConfig = ''
+          fastcgi_pass  127.0.0.1:9000;
+          fastcgi_index index.php;
+          include       ${pkgs.nginx}/conf/fastcgi_params;
+          fastcgi_param SCRIPT_FILENAME /var/www/html$fastcgi_script_name;
+        '';
+      };
+      locations."~* \\.(css|js|png|jpg|webp|woff2|ico)$" = {
+        extraConfig = ''
+          expires 1y;
+          add_header Cache-Control "public, immutable";
+        '';
+      };
+    };
+  };
+
+  # ==========================================================================
+  # SECRETS - auto-generated on first boot
+  # ==========================================================================
+
+  systemd.services."generate-${vmName}-secrets" = {
+    description = "Generate WordPress secret keys and DB password";
+    wantedBy    = [ "multi-user.target" ];
+    after       = [ "local-fs.target" ];
+    before      = [ "mysql.service" "${vmName}-container.service" ];
+    unitConfig.ConditionPathExists = "!${secretsFile}";
+    serviceConfig = {
+      Type            = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = pkgs.writeShellScript "generate-${vmName}-secrets" ''
+        mkdir -p /etc/secrets
+        cat > ${secretsFile} <<EOF
+# WordPress runtime secrets - passwords only
+WORDPRESS_DB_HOST=127.0.0.1
+WORDPRESS_DB_NAME=${vmName}
+WORDPRESS_DB_USER=${vmName}
+WORDPRESS_DB_PASSWORD=$(${pkgs.openssl}/bin/openssl rand -base64 24)
+WORDPRESS_AUTH_KEY=$(${pkgs.openssl}/bin/openssl rand -base64 48)
+WORDPRESS_SECURE_AUTH_KEY=$(${pkgs.openssl}/bin/openssl rand -base64 48)
+WORDPRESS_LOGGED_IN_KEY=$(${pkgs.openssl}/bin/openssl rand -base64 48)
+WORDPRESS_NONCE_KEY=$(${pkgs.openssl}/bin/openssl rand -base64 48)
+WORDPRESS_AUTH_SALT=$(${pkgs.openssl}/bin/openssl rand -base64 48)
+WORDPRESS_SECURE_AUTH_SALT=$(${pkgs.openssl}/bin/openssl rand -base64 48)
+WORDPRESS_LOGGED_IN_SALT=$(${pkgs.openssl}/bin/openssl rand -base64 48)
+WORDPRESS_NONCE_SALT=$(${pkgs.openssl}/bin/openssl rand -base64 48)
+EOF
+        chmod 600 ${secretsFile}
+      '';
+    };
+  };
+
+  # ==========================================================================
+  # MARIADB
+  # ==========================================================================
+
+  services.mysql = {
+    enable  = true;
+    package = pkgs.mariadb;
+    settings.mysqld = {
+      bind-address            = "127.0.0.1";
+      character-set-server    = "utf8mb4";
+      collation-server        = "utf8mb4_unicode_ci";
+      innodb_buffer_pool_size = "512M";
+      max_connections         = 50;
+      query_cache_type        = 1;
+      query_cache_size        = "64M";
+      query_cache_limit       = "2M";
+      slow_query_log          = 1;
+      slow_query_log_file     = "/var/log/mysql/slow.log";
+      long_query_time         = 1;
+    };
+    initialScript = pkgs.writeText "${vmName}-db-init.sql" ''
+      CREATE DATABASE IF NOT EXISTS ${vmName}
+        CHARACTER SET utf8mb4
+        COLLATE utf8mb4_unicode_ci;
+      CREATE USER IF NOT EXISTS '${vmName}'@'localhost'
+        IDENTIFIED BY 'PLACEHOLDER';
+      CREATE USER IF NOT EXISTS '${vmName}'@'127.0.0.1'
+        IDENTIFIED BY 'PLACEHOLDER';
+      GRANT ALL PRIVILEGES ON ${vmName}.* TO '${vmName}'@'localhost';
+      GRANT ALL PRIVILEGES ON ${vmName}.* TO '${vmName}'@'127.0.0.1';
+      FLUSH PRIVILEGES;
+    '';
+  };
+
+  systemd.services."${vmName}-db-password-sync" = {
+    description = "Sync generated DB password into MariaDB";
+    after       = [ "mysql.service" "generate-${vmName}-secrets.service" ];
+    wantedBy    = [ "multi-user.target" ];
+    before      = [ "${vmName}-container.service" ];
+    serviceConfig = {
+      Type            = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = pkgs.writeShellScript "${vmName}-db-password-sync" ''
+        source ${secretsFile}
+        ${pkgs.mariadb}/bin/mysql -u root <<SQL
+          ALTER USER '${vmName}'@'localhost'   IDENTIFIED BY '$WORDPRESS_DB_PASSWORD';
+          ALTER USER '${vmName}'@'127.0.0.1'  IDENTIFIED BY '$WORDPRESS_DB_PASSWORD';
+          FLUSH PRIVILEGES;
+SQL
+      '';
+    };
+  };
+
+  # ==========================================================================
+  # REDIS
+  # ==========================================================================
+
+  services.redis.servers."${vmName}" = {
+    enable   = true;
+    port     = 6380;
+    settings = {
+      maxmemory        = 268435456;
+      maxmemory-policy = "allkeys-lru";
+      save             = lib.mkForce "";
+    };
+  };
+
+  # PHP upload limits — mounted into the container as a custom ini file.
+  # Adjust upload_max_filesize and post_max_size together (post must be >= upload).
+  environment.etc."${vmName}-php/custom.ini".text = ''
+    upload_max_filesize = 128M
+    post_max_size       = 128M
+    max_execution_time  = 300
+    memory_limit        = 256M
+  '';
+
+  # ==========================================================================
+  # WORDPRESS CONTAINER
+  # ==========================================================================
+
+  virtualisation.podman.enable = true;
+
+  systemd.tmpfiles.rules = [
+    # 33:33 = www-data inside the WordPress container (Debian-based image).
+    # 0755 lets host nginx read static files (other=r-x) while the container
+    # process can write uploads/plugins (owner=rwx). Do NOT use 0750/nginx here —
+    # PHP-FPM inside the container runs as uid 33, not the host nginx uid, and
+    # would get permission denied on every request.
+    "d /var/lib/${vmName}         0755 33    33    -"
+    "d /var/backup/${vmName}-db   0700 root  root  -"
+    "d /var/backup/${vmName}-data 0700 root  root  -"
+    "d /var/log/mysql              0755 mysql mysql -"
+    "d /etc/${vmName}-php          0755 root  root  -"
+  ];
+
+  systemd.services."${vmName}-container" = {
+    description = "WordPress via Podman (PHP-FPM)";
+    after = [
+      "network.target"
+      "mysql.service"
+      "generate-${vmName}-secrets.service"
+      "${vmName}-db-password-sync.service"
+      "nginx.service"
+    ];
+    requires = [ "mysql.service" "nginx.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      ExecStartPre = "${pkgs.podman}/bin/podman pull docker.io/wordpress:${versions.wordpress}";
+      ExecStart    = ''
+        ${pkgs.podman}/bin/podman run --rm \
+          --name ${vmName} \
+          --network host \
+          --env-file ${secretsFile} \
+          -e WORDPRESS_REDIS_HOST=127.0.0.1 \
+          -e WORDPRESS_REDIS_PORT=6380 \
+          -e "WORDPRESS_CONFIG_EXTRA=define('WP_HOME','https://${domain}');define('WP_SITEURL','https://${domain}');$$_SERVER['HTTPS']='on';" \
+          -v /var/lib/${vmName}:/var/www/html \
+          -v /etc/${vmName}-php/custom.ini:/usr/local/etc/php/conf.d/custom.ini:ro \
+          docker.io/wordpress:${versions.wordpress}
+      '';
+
+      # ── OPTION: Authentik SSO for wp-admin ──────────────────────────────
+      #
+      # Use when admins/editors should authenticate via Authentik (OIDC).
+      # Public users (readers, commenters) use native WordPress accounts.
+      #
+      # Prerequisites:
+      #   1. Create an OAuth2/OIDC provider in Authentik named "wordpress"
+      #   2. Map Authentik groups to WP roles (see INSTALL.md - Authentication)
+      #   3. Install "OpenID Connect Generic Client" plugin in WordPress
+      #   4. Fill OIDC_* values in /etc/secrets/wordpress.env
+      #   5. Uncomment the env vars below and run: nixos-rebuild switch
+      #   6. Disable the native WP login form via the plugin settings
+      #
+      # -e OIDC_CLIENT_ID=wordpress \
+      # -e OIDC_CLIENT_SECRET=<from Authentik provider> \
+      # -e OIDC_ENDPOINT_LOGIN_URL=https://authentik.<domain>/application/o/wordpress/authorize \
+      # -e OIDC_ENDPOINT_TOKEN_URL=https://authentik.<domain>/application/o/wordpress/token \
+      # -e OIDC_ENDPOINT_USERINFO_URL=https://authentik.<domain>/application/o/wordpress/userinfo \
+      # -e OIDC_ENDPOINT_LOGOUT_URL=https://authentik.<domain>/application/o/wordpress/end-session \
+
+      ExecStop   = "${pkgs.podman}/bin/podman stop ${vmName}";
+      Restart    = "on-failure";
+      RestartSec = "15s";
+
+      # Nginx (host) serves static files from /var/lib/${vmName} as "other".
+      # PHP-FPM (container, www-data uid 33) creates files as 0640 by default,
+      # which gives "other" no read access → 403 on all CSS/JS.
+      # Poll until WordPress has populated the directory, then open permissions.
+      ExecStartPost = pkgs.writeShellScript "${vmName}-fix-perms" ''
+        for i in $(seq 1 30); do
+          test -f /var/lib/${vmName}/wp-includes/version.php && break
+          sleep 2
+        done
+        find /var/lib/${vmName} -type f ! -perm -a+r -exec chmod a+r {} \;
+        find /var/lib/${vmName} -type d ! -perm -a+rx -exec chmod a+rx {} \;
+      '';
+    };
+  };
+
+  # ==========================================================================
+  # BACKUPS
+  # ==========================================================================
+
+  systemd.services."backup-${vmName}-db" = {
+    description = "Daily MariaDB dump for WordPress";
+    serviceConfig = {
+      Type      = "oneshot";
+      ExecStart = pkgs.writeShellScript "backup-${vmName}-db" ''
+        ${pkgs.mariadb}/bin/mysqldump --single-transaction --routines ${vmName} \
+          | ${pkgs.gzip}/bin/gzip > /var/backup/${vmName}-db/${vmName}-$(date +%Y%m%d).sql.gz
+      '';
+    };
+  };
+  systemd.timers."backup-${vmName}-db" = {
+    wantedBy    = [ "timers.target" ];
+    timerConfig = { OnCalendar = "02:00"; Persistent = true; };
+  };
+
+  systemd.services."backup-${vmName}-data" = {
+    description = "Daily file archive for WordPress";
+    serviceConfig = {
+      Type      = "oneshot";
+      ExecStart = pkgs.writeShellScript "backup-${vmName}-data" ''
+        ${pkgs.gnutar}/bin/tar czf \
+          /var/backup/${vmName}-data/${vmName}-$(date +%Y%m%d).tar.gz \
+          /var/lib/${vmName}
+      '';
+    };
+  };
+  systemd.timers."backup-${vmName}-data" = {
+    wantedBy    = [ "timers.target" ];
+    timerConfig = { OnCalendar = "02:30"; Persistent = true; };
+  };
+
+  systemd.services."backup-${vmName}-cleanup" = {
+    description = "Remove WordPress backups older than 30 days";
+    serviceConfig = {
+      Type      = "oneshot";
+      ExecStart = pkgs.writeShellScript "backup-${vmName}-cleanup" ''
+        ${pkgs.findutils}/bin/find /var/backup/${vmName}-db   -mtime +30 -delete
+        ${pkgs.findutils}/bin/find /var/backup/${vmName}-data -mtime +30 -delete
+      '';
+    };
+  };
+  systemd.timers."backup-${vmName}-cleanup" = {
+    wantedBy    = [ "timers.target" ];
+    timerConfig = { OnCalendar = "monthly"; Persistent = true; };
+  };
+
+  # ==========================================================================
+  # SYSTEM PACKAGES
+  # ==========================================================================
+
+  environment.systemPackages = with pkgs; [
+    vim
+    wget
+    curl
+    htop
+    git
+    jq
+    openssl
+    mariadb
+    podman
+  ];
+
+  # ==========================================================================
+  # SYSTEM STATE VERSION - DO NOT CHANGE after initial install
+  # ==========================================================================
+
+  system.stateVersion = "25.05";
+}

--- a/src/modules.json
+++ b/src/modules.json
@@ -5,6 +5,11 @@
             "moduleName": "unifi",
             "vmid": 810,
             "moduleJson": "src/network/unifi/unifi.json"
+        },
+        {
+            "moduleName": "wordpress",
+            "vmid": 620,
+            "moduleJson": "src/AndreasJe/wordpress/wordpress.json"
         }
     ],
     "foundationModules": [],


### PR DESCRIPTION
## feat(wordpress): add self-hosted WordPress CMS module

Adds a WordPress module under `src/AndreasJe/wordpress/`, running on NixOS with a full application stack.
See the module's `README.md`, `INSTALL.md`, and `ADMIN.md` for setup, configuration, and day-to-day operations.

---

**Module added**

| Module | vmid | Status | Description |
|---|---|---|---|
| `wordpress` | 620 | Development | Self-hosted CMS — PHP-FPM, MariaDB, Redis, Nginx, Podman + optional Authentik SSO |

All configuration is driven from `wordpress.json` — vmname, domain, resources, and dependencies. No hardcoded values in the nix file.

Module registered in `src/modules.json`.
