### PR TITLE
fix(euro-office): remove incorrect provides:vm declaration`

### DIFF
--- a/src/AndreasJe/nextcloud-hub/euro-office/euro-office.json
+++ b/src/AndreasJe/nextcloud-hub/euro-office/euro-office.json
@@ -25,7 +25,7 @@
   "proxyDomain": "eu-office.example.com",
   "proxyPort": 80,
   "_containerEnv": "Fields below map directly to container environment variables in euro-office.nix",
-  "containerImage": "ghcr.io/euro-office/documentserver:nightly",
+  "containerImage": "ghcr.io/euro-office/documentserver:build-document-server-custom",
   "exampleEnabled": "false",
   "timeZone": "Europe/Amsterdam",
   "dependsOn": [
@@ -35,7 +35,5 @@
     "firewall:proxy",
     "nextcloud:vm"
   ],
-  "provides": [
-    "vm"
-  ]
+  "provides": []
 }


### PR DESCRIPTION
```
## Summary

Removes `"provides": ["vm"]` from `euro-office.json`.

No module in TAPPaaS or Community declares `dependsOn: ["euro-office:vm"]`.
Euro-office is a leaf module. The incorrect declaration caused
`install-module.sh euro-office` to fail at step 4 on every deploy.

## Test plan

- [ ] `install-module.sh euro-office` passes step 4 without error
- [ ] No existing module breaks (nothing depends on euro-office:vm)

Closes #288
cc @AndreasJe
```