### PR TITLE
feat(modules.json): add repo/stack/category taxonomy fields

### DIFF
--- a/src/modules.json
+++ b/src/modules.json
@@ -3,51 +3,69 @@
     "applicationModules": [
         {
             "moduleName": "nextcloud",
+            "repo": "community",
+            "moduleJson": "src/AndreasJe/nextcloud-hub/nextcloud/nextcloud.json",
             "vmid": 340,
-            "moduleJson": "src/AndreasJe/nextcloud-hub/nextcloud/nextcloud.json"
+            "stack": "productivity",
+            "category": "collaboration"
         },
         {
             "moduleName": "coturn",
+            "repo": "community",
+            "moduleJson": "src/AndreasJe/nextcloud-hub/coturn/coturn.json",
             "vmid": 341,
-            "moduleJson": "src/AndreasJe/nextcloud-hub/coturn/coturn.json"
+            "stack": "infrastructure",
+            "category": "webrtc"
         },
         {
             "moduleName": "nextcloud-hpb",
+            "repo": "community",
+            "moduleJson": "src/AndreasJe/nextcloud-hub/nextcloud-hpb/nextcloud-hpb.json",
             "vmid": 342,
-            "moduleJson": "src/AndreasJe/nextcloud-hub/nextcloud-hpb/nextcloud-hpb.json"
+            "stack": "productivity",
+            "category": "collaboration"
         },
         {
             "moduleName": "euro-office",
+            "repo": "community",
+            "moduleJson": "src/AndreasJe/nextcloud-hub/euro-office/euro-office.json",
             "vmid": 343,
-            "moduleJson": "src/AndreasJe/nextcloud-hub/euro-office/euro-office.json"
+            "stack": "productivity",
+            "category": "documents"
         },
         {
             "moduleName": "unifi",
+            "repo": "community",
+            "moduleJson": "src/ErikDaniel007/network/unifi/unifi.json",
             "vmid": 810,
-            "moduleJson": "src/ErikDaniel007/network/unifi/unifi.json"
+            "stack": "infrastructure",
+            "category": "network"
         },
         {
             "moduleName": "wordpress",
+            "repo": "community",
+            "moduleJson": "src/AndreasJe/wordpress/wordpress.json",
             "vmid": 620,
-            "moduleJson": "src/AndreasJe/wordpress/wordpress.json"
+            "stack": "productivity",
+            "category": "publishing"
         },
         {
             "moduleName": "alfen",
-            "vmid": null,
+            "repo": "community",
             "moduleJson": "src/ErikDaniel007/energy/alfen/alfen.json",
-            "_comment": "Policy-only \u2014 no VM (NG5 sidestep, #157)"
+            "vmid": null
         },
         {
             "moduleName": "sonos",
-            "vmid": null,
+            "repo": "community",
             "moduleJson": "src/ErikDaniel007/entertainment/sonos/sonos.json",
-            "_comment": "Policy-only \u2014 no VM"
+            "vmid": null
         },
         {
             "moduleName": "synology",
-            "vmid": null,
+            "repo": "community",
             "moduleJson": "src/ErikDaniel007/storage/synology/synology.json",
-            "_comment": "Policy-only \u2014 no VM (hardware NAS)"
+            "vmid": null
         }
     ],
     "foundationModules": [],


### PR DESCRIPTION
## Summary

  Adds `repo: "community"`, `stack`, and `category` to all catalog entries,
  following the taxonomy defined in TAPPaaS/TAPPaaS#297.

  Backward compatible — existing scripts ignore new fields.

  Closes #297